### PR TITLE
Fix phpbench for PHP 7

### DIFF
--- a/test/subjects/benchmarks/phpbench-0.8.1/tests/test_ereg.php
+++ b/test/subjects/benchmarks/phpbench-0.8.1/tests/test_ereg.php
@@ -12,9 +12,9 @@ function test_ereg($base) {
     $matches = array();
     do {
 	foreach ($strings as $string) {
-	    if (eregi('^[a-z0-9]+([_\\.-][a-z0-9]+)*' .
-		      '@([a-z0-9]+([\.-][a-z0-9]{1,})+)*$',
-		 $string, $matches) <= 0 ||
+        if (preg_match('/^[a-z0-9]+([_\\.-][a-z0-9]+)*' .
+            '@([a-z0-9]+([\.-][a-z0-9]{1,})+)*$/i',
+            $string, $matches) <= 0 ||
 		empty($matches[2])) {
 		test_regression(__FUNCTION__);
 	    }			   


### PR DESCRIPTION
This patch fix phpbench for PHP version 7 changing the eregi() function
for preg_match() function since eregi is fully deprecated in PHP 7

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>